### PR TITLE
Feature: store items by its name

### DIFF
--- a/src/actions/split.ts
+++ b/src/actions/split.ts
@@ -1,18 +1,23 @@
 import { existsSync, readFileSync } from 'fs';
 import {
-  Collection, Item, ItemGroup, ItemGroupDefinition,
+  Collection,
+  Item,
+  ItemGroup,
+  ItemGroupDefinition,
 } from 'postman-collection';
 import FileHelper from '../helpers/FileHelper';
 import StateHelper from '../helpers/StateHelper';
 import pull from './pull';
 
-function storeDefinition(path:string, json: ItemGroupDefinition): void {
+function storeDefinition(path: string, json: ItemGroupDefinition): void {
   const { item, ...others } = json;
-  FileHelper.writeJson(`${path}/definition.json`, others);
+  const { name = 'definition' } = others;
+
+  FileHelper.writeJson(`${path}/${FileHelper.norm(name)}.json`, others);
 }
 
 function storeItems(item: Item | ItemGroup<Item>, path: string) {
-  const itemDir = FileHelper.mkdir(`${path}/${item.name}`);
+  const itemDir = FileHelper.mkdir(`${path}/${FileHelper.norm(item.name)}`);
   storeDefinition(itemDir, item.toJSON());
   if (item instanceof ItemGroup) {
     item.items.each((childItem) => {
@@ -26,12 +31,15 @@ function storeItems(item: Item | ItemGroup<Item>, path: string) {
 
 export default async function split(stateKey: string) {
   const currentState = StateHelper.get(stateKey);
-  const resource = (existsSync(currentState.path)) ? JSON.parse(readFileSync(currentState.path, 'utf8')) : await pull(stateKey);
+  const resource = existsSync(currentState.path)
+    ? JSON.parse(readFileSync(currentState.path, 'utf8'))
+    : await pull(stateKey);
   const collection = new Collection(resource);
   if (!Collection.isCollection(collection)) {
     throw new Error(`Can't load valid Collection from stateKey:${stateKey}`);
   }
-  const splitDir = currentState.dir ?? currentState.path.substring(0, currentState.path.lastIndexOf('/'));
+  const splitDir = currentState.dir
+    ?? currentState.path.substring(0, currentState.path.lastIndexOf('/'));
   FileHelper.mkdir(`${splitDir}/items`);
   storeDefinition(splitDir, collection.toJSON());
   collection.items.each((item) => {

--- a/src/helpers/FileHelper.ts
+++ b/src/helpers/FileHelper.ts
@@ -1,8 +1,16 @@
 import fs from 'fs';
 
 class FileHelper {
+  // convert str to acceptable file name or path
+  public static norm(str: string): string {
+    return str.replace(/[^a-z0-9.]/gi, '_').toLowerCase();
+  }
+
   public static mkdir(path: string): string {
-    const cleanPath = path.replace(/[~#%&*{}\\:<>? +|]/g, '_');
+    const cleanPath = path
+      .split('/')
+      .map((dirFile) => FileHelper.norm(dirFile))
+      .join('/');
     if (!fs.existsSync(cleanPath)) {
       fs.mkdirSync(cleanPath, { recursive: true });
     }


### PR DESCRIPTION
In the past month, I have noticed that using the same name to store each item in a Postman collection can be confusing when multiple definitions are opened simultaneously. T
herefore, in this pull request, I have made the change to store items based on their respective names.